### PR TITLE
Fix spelling: Github -> GitHub on gh-pages

### DIFF
--- a/api.html
+++ b/api.html
@@ -41,7 +41,7 @@
                     <br>
                     <a href="./customize.html" class="button">Customize</a>
                     <br>
-                    <a href="https://github.com/fians/marka/" class="button">Github</a>
+                    <a href="https://github.com/fians/marka/" class="button">GitHub</a>
                 </div>
             </div>
             <div class="content">

--- a/faq.html
+++ b/faq.html
@@ -41,7 +41,7 @@
                     <br>
                     <a href="./customize.html" class="button">Customize</a>
                     <br>
-                    <a href="https://github.com/fians/marka/" class="button">Github</a>
+                    <a href="https://github.com/fians/marka/" class="button">GitHub</a>
                 </div>
             </div>
             <div class="content">
@@ -61,7 +61,7 @@ and Opera. And off course IE10+.</li>
 </li>
 <li><p><strong>I found a bug, where should I reported to?</strong></p>
 <ul>
-<li>Oh, great! Just report the issue in <a href="https://github.com/fians/marka/issues">Marka&#39;s Github repo</a>.</li>
+<li>Oh, great! Just report the issue in <a href="https://github.com/fians/marka/issues">Marka&#39;s GitHub repo</a>.</li>
 </ul>
 </li>
 </ol>

--- a/getting-started.html
+++ b/getting-started.html
@@ -41,7 +41,7 @@
                     <br>
                     <a href="./customize.html" class="button">Customize</a>
                     <br>
-                    <a href="https://github.com/fians/marka/" class="button">Github</a>
+                    <a href="https://github.com/fians/marka/" class="button">GitHub</a>
                 </div>
             </div>
             <div class="content">

--- a/icons.html
+++ b/icons.html
@@ -42,7 +42,7 @@
                     <br>
                     <a href="./customize.html" class="button">Customize</a>
                     <br>
-                    <a href="https://github.com/fians/marka/" class="button">Github</a>
+                    <a href="https://github.com/fians/marka/" class="button">GitHub</a>
                 </div>
             </div>
             <div class="content">


### PR DESCRIPTION
Via:

```
perl -i -pe 's/Github/GitHub/g' `git grep -l Github`
```
